### PR TITLE
allow userid to be supplied in connection string for demos

### DIFF
--- a/bin/conf.js
+++ b/bin/conf.js
@@ -46,8 +46,9 @@ export const conf = {
   server: {
     port: number.parseInt(env.getConf('port') || '4400'),
     auth: types.createAuthPlugin({
-      // this demo configuration picks a "unique" userid and grants everyone write access
-      async readAuthInfo (_req) { return { userid: random.oneOf(userIdChoices) } },
+      // this demo configuration takes the userid from `?userid=` (or picks a "unique" one) and
+      // grants everyone write access
+      async readAuthInfo (req) { return { userid: req.getQuery('userid') || random.oneOf(userIdChoices) } },
       async getAccessType () { return 'rw' }
     })
   },


### PR DESCRIPTION
The demo will always pick a random username to attribute content to, this makes it unsuable for certain kinds of demos (where you want names to be stable or user generated). So, this change allows you to pass them in via the connection string for demos only.