### PR TITLE
add mergeUsers to the activity API

### DIFF
--- a/API.md
+++ b/API.md
@@ -249,7 +249,7 @@ The `ydoc` is the document at `to`; its alive content already *is* that point-in
 Retrieve all editing-timestamps for a certain document. Use
 the activity API and the changeset API to reconstruct an editing trail.
 
-* `GET /api/activity/v1/{org}/{docid}` parameters: `{ from?: number, to?: number, by?: string, limit?: number, order?: string, group?: boolean, groupMaxGap?: number, groupMaxDuration?: number, delta?: boolean, withCustomAttributions?: string, customAttributions?: boolean, contentIds?: string }`
+* `GET /api/activity/v1/{org}/{docid}` parameters: `{ from?: number, to?: number, by?: string, limit?: number, order?: string, group?: boolean, groupMaxGap?: number, groupMaxDuration?: number, mergeUsers?: boolean, delta?: boolean, withCustomAttributions?: string, customAttributions?: boolean, contentIds?: string }`
   * `from`/`to`: unix timestamp range filter
   * `by=string`: comma-separated list of user-ids to filter by
   * `withCustomAttributions=string`: filter by custom attributions using `key:value` pairs, comma-separated (e.g. `source:import,tag:v2`). Only changes matching all specified attributions are included.
@@ -257,8 +257,9 @@ the activity API and the changeset API to reconstruct an editing trail.
   * `limit=number`: maximum number of entries to return
   * `order='asc'|'desc'`: `"asc"` (oldest first) or `"desc"` (newest first, default)
   * `group=boolean`: bundle consecutive changes from the same user into a single entry (experimental)
-  * `groupMaxGap=number`: maximum time gap (in milliseconds) between consecutive changes by the same user that still merges them into a single entry (default: `1000`). Only applies when grouping is enabled.
+  * `groupMaxGap=number`: maximum time gap (in milliseconds) between consecutive changes that still merges them into a single entry (default: `1000`). Only applies when grouping is enabled.
   * `groupMaxDuration=number`: maximum total span (in milliseconds) of a grouped entry (`entry.to - entry.from`). A change is not merged into a group if the resulting span would exceed this value (default: unlimited). Only applies when grouping is enabled.
+  * `mergeUsers=boolean`: also bundle consecutive changes from *different* users into a single entry, so that grouping is decided purely by `groupMaxGap`/`groupMaxDuration` (default: `false`). The entry's `by` then lists every contributing user-id, comma-separated in order of first appearance — the same encoding `by=` accepts as a filter. Only applies when grouping is enabled. Useful for a "what happened to this document between 9am and 10am" timeline, where interleaved edits by several people should read as one session rather than one entry per author switch.
   * `delta=boolean`: include a delta representation for each activity entry — the document at that entry's `to`, with the entry's changes highlighted.
   * `ydoc=boolean`: return a single shared partially-gc'd document for the whole list, plus per entry a `renderedContent` IdSet (= content alive at the entry's `to`). The response shape becomes `{ ydoc, activity }`. Render any entry client-side by applying `ydoc` to a `gc: false` doc and overlaying an `AttributionsRenderer` with that entry's `renderedContent` (and `attributions`) — see [Rendering with AttributionsRenderer](#rendering-with-attributionsrenderer).
   * `attributions=boolean`: include each entry's attribution `ContentMap` (as `attributions: Uint8Array`).

--- a/src/builtin-api.js
+++ b/src/builtin-api.js
@@ -186,6 +186,7 @@ const activityEndpoint = createApiEndpoint('activity', {
       group: s.$boolean.optional,
       groupMaxGap: s.$number.optional,
       groupMaxDuration: s.$number.optional,
+      mergeUsers: s.$boolean.optional,
       customAttributions: s.$boolean.optional,
       // raw `k:v,k:v` string - parsed in the handler; the raw string is part of the cache key
       withCustomAttributions: s.$string.optional,
@@ -205,15 +206,16 @@ const activityEndpoint = createApiEndpoint('activity', {
       const group = query.group ?? true
       const groupMaxGap = query.groupMaxGap ?? 1000
       const groupMaxDuration = query.groupMaxDuration ?? number.MAX_SAFE_INTEGER
+      const mergeUsers = query.mergeUsers ?? false
       const withCustomAttributions = query.withCustomAttributions ? parseCustomAttributionsParam(query.withCustomAttributions) : null
       const includeCustomAttributions = query.customAttributions ?? false
       const contentIds = query.contentIds ? buffer.fromBase64(query.contentIds) : undefined
       try {
-        const cacheArgs = [String(from), String(to), by, String(includeDelta), String(includeYdoc), String(includeAttributions), String(limit), reverse ? 'desc' : 'asc', String(group), String(groupMaxGap), String(groupMaxDuration), query.withCustomAttributions || '', String(includeCustomAttributions), query.contentIds || '']
+        const cacheArgs = [String(from), String(to), by, String(includeDelta), String(includeYdoc), String(includeAttributions), String(limit), reverse ? 'desc' : 'asc', String(group), String(groupMaxGap), String(groupMaxDuration), String(mergeUsers), query.withCustomAttributions || '', String(includeCustomAttributions), query.contentIds || '']
         return encodedAny(await req.yhub.stream.cachedGet(room, 'activity', cacheArgs, async () => {
           const { contentmap: contentmapBin, nongcDoc, tombstone } = await req.yhub.getDoc(room, { nongc: true, contentmap: true })
           if (tombstone != null) throw new DocDeletedError(room, tombstone)
-          return req.yhub.computePool.activity({ nongcDoc, contentmapBin, from, to, by, contentIds, withCustomAttributions, includeCustomAttributions, includeDelta, includeYdoc, includeAttributions, limit, reverse, group, groupMaxGap, groupMaxDuration }, { room })
+          return req.yhub.computePool.activity({ nongcDoc, contentmapBin, from, to, by, contentIds, withCustomAttributions, includeCustomAttributions, includeDelta, includeYdoc, includeAttributions, limit, reverse, group, groupMaxGap, groupMaxDuration, mergeUsers }, { room })
         }))
       } catch (err) {
         // see the changeset endpoint

--- a/src/compute-worker.js
+++ b/src/compute-worker.js
@@ -126,7 +126,7 @@ port.on('message', /** @param {import('./compute.js').ComputeTask} msg */ msg =>
       break
     }
     case 'activity': {
-      const { nongcDoc: nongcDocBin, contentmapBin, from, to, by, contentIds: contentIdsBin, withCustomAttributions, includeCustomAttributions, includeDelta, includeYdoc, includeAttributions, limit, reverse, group, groupMaxGap, groupMaxDuration } = msg
+      const { nongcDoc: nongcDocBin, contentmapBin, from, to, by, contentIds: contentIdsBin, withCustomAttributions, includeCustomAttributions, includeDelta, includeYdoc, includeAttributions, limit, reverse, group, groupMaxGap, groupMaxDuration, mergeUsers } = msg
       const contentmap = Y.decodeContentMap(contentmapBin)
       const contentIds = contentIdsBin && Y.decodeContentIds(contentIdsBin)
       const filteredAttributions = filterContentMap(contentmap, from, to, by || undefined, contentIds, withCustomAttributions)
@@ -180,13 +180,21 @@ port.on('message', /** @param {import('./compute.js').ComputeTask} msg */ msg =>
       const groupDistance = group ? groupMaxGap : 1
       /** @type {{ from: number, to: number, by: string?, customAttributions: Array<{k:string,v:string}>|null }|null} */
       let lastActivity = null
+      // authors of `lastActivity`, only tracked when mergeUsers lets entries span multiple users
+      /** @type {Set<string>} */
+      let lastBy = new Set()
       activity.forEach(act => {
-        if (lastActivity != null && lastActivity.by === act.by && act.from - lastActivity.to < groupDistance && act.to - lastActivity.from < groupMaxDuration) {
+        if (lastActivity != null && (mergeUsers || lastActivity.by === act.by) && act.from - lastActivity.to < groupDistance && act.to - lastActivity.from < groupMaxDuration) {
           lastActivity.to = act.to
+          if (mergeUsers && act.by) {
+            act.by.split(',').forEach(u => lastBy.add(u))
+            lastActivity.by = Array.from(lastBy).join(',')
+          }
           lastActivity.customAttributions?.push(...(act?.customAttributions || []))
         } else {
           activityResult.push(act)
           lastActivity = act
+          if (mergeUsers) lastBy = new Set(act.by ? act.by.split(',') : [])
         }
       })
       if (includeCustomAttributions) {

--- a/src/compute.js
+++ b/src/compute.js
@@ -60,7 +60,8 @@ const $computeTask = s.$union(
     reverse: s.$boolean,
     group: s.$boolean,
     groupMaxGap: s.$number,
-    groupMaxDuration: s.$number
+    groupMaxDuration: s.$number,
+    mergeUsers: s.$boolean
   }),
   s.$object({
     type: s.$literal('patchYdoc'),
@@ -362,6 +363,7 @@ class ComputePool {
    * @param {boolean} opts.group
    * @param {number} opts.groupMaxGap
    * @param {number} opts.groupMaxDuration
+   * @param {boolean} opts.mergeUsers
    * @param {Object<string, any>} [logContext]
    * @returns {Promise<Uint8Array<ArrayBuffer>>}
    */

--- a/tests/computeWorker.tests.js
+++ b/tests/computeWorker.tests.js
@@ -139,6 +139,7 @@ export const testActivityGrouping = async _tc => {
     group: true,
     groupMaxGap: 1000,
     groupMaxDuration: Number.MAX_SAFE_INTEGER,
+    mergeUsers: false,
     ...opts
   }))).activity
   // default: 500ms gaps are below groupMaxGap=1000, everything merges
@@ -152,6 +153,75 @@ export const testActivityGrouping = async _tc => {
   t.compare(capped.map(a => [a.from, a.to]), [[1000, 1500], [2000, 2000]])
   const ungrouped = await activity({ group: false })
   t.assert(ungrouped.length === 3)
+  doc.destroy()
+  await pool.destroy()
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testActivityMergeUsers = async _tc => {
+  const pool = createComputePool({ poolSize: 2 })
+  const doc = new Y.Doc({ gc: false })
+  // three edits at timestamps 1000, 1500, 2000, authored user1 -> user2 -> user1
+  /** @type {Array<Y.ContentMap>} */
+  const contentmaps = []
+  let prevContentIds = Y.createContentIdsFromUpdate(Y.encodeStateAsUpdate(new Y.Doc()))
+  /**
+   * @param {string} text
+   * @param {string} user
+   * @param {number} at
+   */
+  const edit = (text, user, at) => {
+    doc.get('test').insert(doc.get('test').length, text)
+    const contentIds = Y.createContentIdsFromUpdate(Y.encodeStateAsUpdate(doc))
+    contentmaps.push(Y.createContentMapFromContentIds(
+      Y.excludeContentIds(contentIds, prevContentIds),
+      [Y.createContentAttribute('insert', user), Y.createContentAttribute('insertAt', at)],
+      [Y.createContentAttribute('delete', user), Y.createContentAttribute('deleteAt', at)]
+    ))
+    prevContentIds = contentIds
+  }
+  edit('hello', 'user1', 1000)
+  edit(' world', 'user2', 1500)
+  edit('!', 'user1', 2000)
+  const nongcDoc = Y.encodeStateAsUpdate(doc)
+  const contentmapBin = Y.encodeContentMap(Y.mergeContentMaps(contentmaps))
+  /**
+   * @param {object} opts
+   * @return {Promise<Array<{ from: number, to: number, by: string? }>>}
+   */
+  const activity = async (opts = {}) => decoding.readAny(decoding.createDecoder(await pool.activity({
+    nongcDoc,
+    contentmapBin,
+    from: 0,
+    to: Number.MAX_SAFE_INTEGER,
+    by: '',
+    withCustomAttributions: null,
+    includeCustomAttributions: false,
+    includeDelta: false,
+    includeYdoc: false,
+    includeAttributions: false,
+    limit: Number.MAX_SAFE_INTEGER,
+    reverse: false,
+    group: true,
+    groupMaxGap: 1000,
+    groupMaxDuration: Number.MAX_SAFE_INTEGER,
+    mergeUsers: false,
+    ...opts
+  }))).activity
+  // without mergeUsers the author changes on every edit, so nothing groups
+  const perUser = await activity({})
+  t.compare(perUser.map(a => [a.from, a.to, a.by]), [[1000, 1000, 'user1'], [1500, 1500, 'user2'], [2000, 2000, 'user1']])
+  // with mergeUsers the gaps alone decide: one entry listing both authors, user1 not repeated
+  const merged = await activity({ mergeUsers: true })
+  t.compare(merged.map(a => [a.from, a.to, a.by]), [[1000, 2000, 'user1,user2']])
+  // mergeUsers still respects groupMaxGap
+  const smallGap = await activity({ mergeUsers: true, groupMaxGap: 400 })
+  t.compare(smallGap.map(a => [a.from, a.to, a.by]), [[1000, 1000, 'user1'], [1500, 1500, 'user2'], [2000, 2000, 'user1']])
+  // ...and groupMaxDuration: the third edit would span 1000ms >= 600, so it starts a new group
+  const capped = await activity({ mergeUsers: true, groupMaxGap: 10000, groupMaxDuration: 600 })
+  t.compare(capped.map(a => [a.from, a.to, a.by]), [[1000, 1500, 'user1,user2'], [2000, 2000, 'user1']])
   doc.destroy()
   await pool.destroy()
 }


### PR DESCRIPTION
This adds an option to the API to group users together, which would make `groupMaxGap` & `groupMaxDuration` be the only properties respected when doing grouping. This results in less activity items for interleaving authors. Default `false` for back-compat. Multiple users where already represented as a merged `by` string, so this just re-uses that logic to attribute the activity item to multiple users.